### PR TITLE
change composer version to 1.10.19

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - laravel
 
   composer:
-    image: composer:latest
+    image: composer:1.10.19
     container_name: composer
     volumes:
       - .:/var/www/html


### PR DESCRIPTION
Since composer:latest has been updated to use php8.0, we can't install the dependencies in our localhost. This changes the php version of the composer container to be 7.4
